### PR TITLE
Add Dockerfile for Cloud Run deployment compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8080
+
+WORKDIR /app
+
+# Install system dependencies required by scientific Python stack.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy project files into the container image.
+COPY . /app
+
+# Install the Meridian package and its runtime dependencies.
+RUN pip install --upgrade pip && \
+    pip install .
+
+# Expose the port Cloud Run will connect to.
+EXPOSE ${PORT}
+
+# Start a very small HTTP server so the container is reachable by Cloud Run.
+CMD ["python", "cloud_run_entry.py"]

--- a/cloud_run_entry.py
+++ b/cloud_run_entry.py
@@ -1,0 +1,34 @@
+"""Minimal HTTP server so the Meridian image is Cloud Run compatible."""
+
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import os
+
+
+class _HealthCheckHandler(BaseHTTPRequestHandler):
+  """Responds with a short message confirming the service is running."""
+
+  def do_GET(self):  # pylint: disable=invalid-name
+    message = "Meridian service is running."
+    body = message.encode("utf-8")
+
+    self.send_response(HTTPStatus.OK)
+    self.send_header("Content-Type", "text/plain; charset=utf-8")
+    self.send_header("Content-Length", str(len(body)))
+    self.end_headers()
+    self.wfile.write(body)
+
+  def log_message(self, format, *args):  # pylint: disable=redefined-builtin
+    # Silence the default request logging to keep Cloud Run logs cleaner.
+    return
+
+
+def main():
+  port = int(os.environ.get("PORT", "8080"))
+  server_address = ("", port)
+  httpd = ThreadingHTTPServer(server_address, _HealthCheckHandler)
+  httpd.serve_forever()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs the project and configures a Cloud Run friendly runtime
- provide a lightweight HTTP entrypoint that keeps the container responsive

## Testing
- python -m compileall cloud_run_entry.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2db734cc8328b5bcace952bf4c7f